### PR TITLE
Add kill_require_summon

### DIFF
--- a/src/main/java/vg/civcraft/mc/prisonpearl/PrisonPearlConfig.java
+++ b/src/main/java/vg/civcraft/mc/prisonpearl/PrisonPearlConfig.java
@@ -62,6 +62,11 @@ public class PrisonPearlConfig {
 	}
 	
 	
+	public static boolean requireSummonToKill() {
+		return PrisonPearlPlugin.getInstance().getConfig().getBoolean("kill_require_summon");
+	}
+	
+	
 	public static boolean shouldPpsummonClearInventory() {
 		return PrisonPearlPlugin.getInstance().getConfig().getBoolean("prison.clearinventoryonsummon");
 	}

--- a/src/main/java/vg/civcraft/mc/prisonpearl/command/commands/Kill.java
+++ b/src/main/java/vg/civcraft/mc/prisonpearl/command/commands/Kill.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civmodcore.command.PlayerCommand;
 import vg.civcraft.mc.prisonpearl.PrisonPearl;
 import vg.civcraft.mc.prisonpearl.PrisonPearlPlugin;
+import vg.civcraft.mc.prisonpearl.PrisonPearlConfig;
 import vg.civcraft.mc.prisonpearl.managers.PrisonPearlManager;
 
 public class Kill extends PlayerCommand {
@@ -46,6 +47,12 @@ public class Kill extends PlayerCommand {
 					+ "The player held in this pearl is not online");
 			return true;
 		}
+		if (PrisonPearlConfig.requireSummonToKill() && !PrisonPearlPlugin.getSummonManager().isSummoned(imprisoned)) {
+			p.sendMessage(ChatColor.RED
+					+ "The player held in this pearl is not summoned, so they can't be killed");
+			return true;
+		}
+
 		imprisoned.damage(1000000.0); // should be enough
 		imprisoned.sendMessage(ChatColor.YELLOW
 				+ "You were struck down by your imprisoner");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,5 @@
 free_tppearl: true
+kill_require_summon: true
 autofree_worldborder: true
 prison_musthotbar: true
 prison_stealing: true


### PR DESCRIPTION
If this option is enabled, you must first summon a player before killing them with `/ppkill`.